### PR TITLE
Add NullKia mobile security framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@
 * [Runtime Mobile Security (RMS) - is a powerful web interface that helps you to manipulate Android and iOS Apps at Runtime](https://github.com/m0bilesecurity/RMS-Runtime-Mobile-Security)
 * [House: A runtime mobile application analysis toolkit with a Web GUI](https://github.com/nccgroup/house)
 * [Objection - Runtime Mobile Exploration toolkit, powered by Frida](https://github.com/sensepost/objection)
+* [NullKia](https://github.com/bad-antics/nullkia) - Mobile security framework supporting 18 manufacturers with baseband exploitation, TEE/TrustZone research, cellular security, and eSIM tools
 * [Droid-FF - Android File Fuzzing Framework](https://github.com/antojoseph/droid-ff)
 * [Drozer](https://github.com/FSecureLABS/drozer)
 * [Slicer-automate APK Recon](https://github.com/mzfr/slicer)


### PR DESCRIPTION
## Description

Adds [NullKia](https://github.com/bad-antics/nullkia) to the Dynamic Analysis tools section.

## About NullKia v3.0

Comprehensive mobile security framework featuring:

| Feature | Description |
|---------|-------------|
| 📱 **18 Manufacturers** | Samsung, Apple, Google, OnePlus, Xiaomi, Huawei, Motorola, LG, Sony, Nokia, Nothing, OPPO, Vivo, Realme, ASUS, ZTE, Fairphone, TCL |
| 📡 **Baseband Tools** | Shannon, Qualcomm, MediaTek, Exynos, Apple modem exploitation |
| 📶 **Cellular Security** | 5G/LTE security, eSIM tools, IMSI analysis, carrier unlock |
| 🔐 **TEE/TrustZone** | Secure Element, BootROM extraction, TrustZone research |
| 🖥️ **GUI Dashboard** | Interactive interface with extensible plugin architecture |

## Checklist

- [x] Follows existing format
- [x] Placed in Dynamic Analysis section
- [x] Description is concise and relevant